### PR TITLE
Use four-component RGBA for vertex colors

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -971,9 +971,9 @@ class EggGroup(EggGroupNode):
 
             if vertex.color:
                 self.have_vertex_colors = True
-                self.vertex_colors += vertex.color[:3]
+                self.vertex_colors += vertex.color
             else:
-                self.vertex_colors += (1, 1, 1)
+                self.vertex_colors += (1, 1, 1, 1)
 
             for name, uv in vertex.uv_map.items():
                 if name not in mesh.uv_layers:


### PR DESCRIPTION
Fixes #5 

Blender is expecting 4 components for vertex colors, but the importer was using 3, which was causing the error in #5. I am unsure if this is a recent change to Blender's API or not. This would be worth investigating if there are plans to support older versions of Blender.